### PR TITLE
CI: AVX2/AVX‑512/NEON でのビルド・テストを追加 (vibe-kanban 4c682469)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,91 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-test-matrix:
+    name: Build & Test (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x64-avx2
+            os: ubuntu-latest
+            rustflags: -C target-cpu=haswell
+            run_tests: true
+          - name: x64-avx512-build
+            os: ubuntu-latest
+            rustflags: -C target-cpu=skylake-avx512
+            run_tests: false # build only to avoid SIGILL
+          - name: arm64-neon
+            # If available, use GitHub-hosted ARM64 runner
+            # e.g. ubuntu-24.04-arm64 (org setting dependent)
+            # If unavailable, consider: [self-hosted, Linux, ARM64]
+            os: ubuntu-24.04-arm64
+            rustflags: -C target-feature=+neon
+            run_tests: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: Build (release)
+        run: cargo build --workspace --release --verbose
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+      - name: Test (release)
+        if: ${{ matrix.run_tests == true }}
+        run: cargo test --workspace --release --verbose
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
+
+  clippy:
+    runs-on: ubuntu-latest
+    name: Clippy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: Clippy (deny warnings)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    name: Rustfmt
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+


### PR DESCRIPTION
branche name: feat/multi_arch_ci

## 背景
- 本ワークスペースの SIMD 最適化（AVX2/AVX‑512/NEON）コードパスの劣化検知が必要 。
- GitHub ホストランナーは AVX‑512 を保証せず、ARM64 も環境により未提供のため、実行戦略を分離。
  - AVX2: x86_64 ランナーでビルド＋テストを実行。
  - AVX‑512: x86_64 ランナーでは未対応の可能性が高く、ビルドのみで担保。
  - NEON: ARM64 ランナー（例: `ubuntu-24.04-arm64` または `self-hosted, Linux, ARM64`）でビルド＋テストを実行。

## スコープ
- `.github/workflows/rust.yml` の Build & Test を CPU 機能マトリクス化。
- x86_64/AVX2 は実行テストまで、x86_64/AVX‑512 はビルドのみ、ARM64/NEON は実行テストまで。
- 既存の Clippy/Fmt ジョブは維持。
- すべて nightly、`Swatinem/rust-cache@v2`、`RUST_BACKTRACE=1` を適用。

## 受け入れ条件
- Push/PR で以下が動作:
  - x64/AVX2: リリースビルド＋テストが成功。
  - x64/AVX‑512: リリースビルドが成功（テストはスキップ）。
  - ARM64/NEON: リリースビルド＋テストが成功（ARM64 ランナーが利用可能な場合）。
- Clippy/Fmt は従来通り、警告・未整形で CI が失敗。
- 2 回目以降の実行でビルドキャッシュが効く。

## 注意点
- AVX‑512 はホストランナーで未対応の可能性が高く、テスト実行は SIGILL 回避のためスキップ。
- ARM64 ランナーが未提供の場合は NEON 行を一時的にコメントアウト、または `self-hosted` ラベル運用に切替。
- 実行テストは `is_x86_feature_detected!` や `cfg(target_feature)` で条件化し、誤実行を防止。

## 提案する rust.yml（差し替え案）
```yaml
name: Rust CI

on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]
  workflow_dispatch:

permissions:
  contents: read

concurrency:
  group: rust-ci-${{ github.ref }}
  cancel-in-progress: true

env:
  CARGO_TERM_COLOR: always
  RUST_BACKTRACE: 1

jobs:
  build-test-matrix:
    name: Build & Test (${{ matrix.name }})
    runs-on: ${{ matrix.os }}
    strategy:
      fail-fast: false
      matrix:
        include:
          - name: x64-avx2
            os: ubuntu-latest
            rustflags: -C target-cpu=haswell
            run_tests: true
          - name: x64-avx512-build
            os: ubuntu-latest
            rustflags: -C target-cpu=skylake-avx512
            run_tests: false  # build only to avoid SIGILL
          - name: arm64-neon
            # 利用可能な場合は GitHub ホスト ARM64 ランナーに置換
            # 例: ubuntu-24.04-arm64（組織設定依存）
            # 未提供時は self-hosted を使用: [self-hosted, Linux, ARM64]
            os: ubuntu-24.04-arm64
            rustflags: -C target-feature=+neon
            run_tests: true
    steps:
      - uses: actions/checkout@v4
      - name: Install nightly toolchain
        uses: actions-rust-lang/setup-rust-toolchain@v1
        with:
          toolchain: nightly
      - name: Cache cargo build
        uses: Swatinem/rust-cache@v2
      - name: Build (release)
        run: cargo build --workspace --release --verbose
        env:
          RUSTFLAGS: ${{ matrix.rustflags }}
      - name: Test (release)
        if: ${{ matrix.run_tests == true }}
        run: cargo test --workspace --release --verbose
        env:
          RUSTFLAGS: ${{ matrix.rustflags }}
  clippy:
    runs-on: ubuntu-latest
    name: Clippy
    steps:
      - uses: actions/checkout@v4
      - name: Install nightly toolchain
        uses: actions-rust-lang/setup-rust-toolchain@v1
        with:
          toolchain: nightly
          components: clippy
      - name: Cache cargo build
        uses: Swatinem/rust-cache@v2
      - name: Clippy (deny warnings)
        run: cargo clippy --workspace --all-targets --all-features -- -D warning
s

  fmt:
    runs-on: ubuntu-latest
    name: Rustfmt
    steps:
      - uses: actions/checkout@v4
      - name: Install nightly toolchain
        uses: actions-rust-lang/setup-rust-toolchain@v1
        with:
          toolchain: nightly
          components: rustfmt
      - name: Cache cargo build
        uses: Swatinem/rust-cache@v2
      - name: Check formatting
        run: cargo fmt --all -- --check
```