### PR TITLE
Applied the Clippy-suggested idioms across the utils crate so the rep…

### DIFF
--- a/crates/air/src/prove.rs
+++ b/crates/air/src/prove.rs
@@ -122,7 +122,7 @@ impl<EF: ExtensionField<PF<EF>>, A: NormalAir<EF>, AP: PackedAir<EF>> AirTable<E
         univariate_skips: usize,
         witness: AirWitness<'a, PF<EF>>,
     ) -> Vec<Evaluation<EF>> {
-        prove_air::<PF<EF>, EF, A, AP>(prover_state, univariate_skips, &self, witness)
+        prove_air::<PF<EF>, EF, A, AP>(prover_state, univariate_skips, self, witness)
     }
 
     #[instrument(name = "air: prove in extension", skip_all)]
@@ -132,7 +132,7 @@ impl<EF: ExtensionField<PF<EF>>, A: NormalAir<EF>, AP: PackedAir<EF>> AirTable<E
         univariate_skips: usize,
         witness: AirWitness<'a, EF>,
     ) -> Vec<Evaluation<EF>> {
-        prove_air::<EF, EF, A, AP>(prover_state, univariate_skips, &self, witness)
+        prove_air::<EF, EF, A, AP>(prover_state, univariate_skips, self, witness)
     }
 }
 
@@ -224,9 +224,13 @@ fn open_structured_columns<'a, EF: ExtensionField<PF<EF>> + ExtensionField<IF>, 
     let mut column_scalars = vec![];
     let mut index = 0;
     for group in &witness.column_groups {
-        for i in index..index + group.len() {
-            column_scalars.push(poly_eq_batching_scalars[i]);
-        }
+        column_scalars.extend(
+            poly_eq_batching_scalars
+                .iter()
+                .skip(index)
+                .take(group.len())
+                .copied(),
+        );
         index += witness.max_columns_per_group().next_power_of_two();
     }
 

--- a/crates/air/src/table.rs
+++ b/crates/air/src/table.rs
@@ -81,18 +81,18 @@ impl<EF: ExtensionField<PF<EF>>, A: NormalAir<EF>, AP: PackedAir<EF>> AirTable<E
                 };
                 if TypeId::of::<IF>() == TypeId::of::<EF>() {
                     unsafe {
-                        self.air
-                            .eval(transmute::<_, &mut ConstraintChecker<'_, EF, EF>>(
-                                &mut constraints_checker,
-                            ));
+                        self.air.eval(transmute::<
+                            &mut ConstraintChecker<'_, IF, EF>,
+                            &mut ConstraintChecker<'_, EF, EF>,
+                        >(&mut constraints_checker));
                     }
                 } else {
                     assert_eq!(TypeId::of::<IF>(), TypeId::of::<PF<EF>>());
                     unsafe {
-                        self.air
-                            .eval(transmute::<_, &mut ConstraintChecker<'_, PF<EF>, EF>>(
-                                &mut constraints_checker,
-                            ));
+                        self.air.eval(transmute::<
+                            &mut ConstraintChecker<'_, IF, EF>,
+                            &mut ConstraintChecker<'_, PF<EF>, EF>,
+                        >(&mut constraints_checker));
                     }
                 }
                 handle_errors(row, &mut constraints_checker)?;
@@ -110,18 +110,18 @@ impl<EF: ExtensionField<PF<EF>>, A: NormalAir<EF>, AP: PackedAir<EF>> AirTable<E
                 };
                 if TypeId::of::<IF>() == TypeId::of::<EF>() {
                     unsafe {
-                        self.air
-                            .eval(transmute::<_, &mut ConstraintChecker<'_, EF, EF>>(
-                                &mut constraints_checker,
-                            ));
+                        self.air.eval(transmute::<
+                            &mut ConstraintChecker<'_, IF, EF>,
+                            &mut ConstraintChecker<'_, EF, EF>,
+                        >(&mut constraints_checker));
                     }
                 } else {
                     assert_eq!(TypeId::of::<IF>(), TypeId::of::<PF<EF>>());
                     unsafe {
-                        self.air
-                            .eval(transmute::<_, &mut ConstraintChecker<'_, PF<EF>, EF>>(
-                                &mut constraints_checker,
-                            ));
+                        self.air.eval(transmute::<
+                            &mut ConstraintChecker<'_, IF, EF>,
+                            &mut ConstraintChecker<'_, PF<EF>, EF>,
+                        >(&mut constraints_checker));
                     }
                 }
                 handle_errors(row, &mut constraints_checker)?;

--- a/crates/air/src/test.rs
+++ b/crates/air/src/test.rs
@@ -105,16 +105,41 @@ fn generate_structured_trace<const N_COLUMNS: usize, const N_PREPROCESSED_COLUMN
         trace.push((0..n_rows).map(|_| rng.random()).collect::<Vec<F>>());
     }
     let mut witness_cols = vec![vec![F::ZERO]; N_COLUMNS - N_PREPROCESSED_COLUMNS];
-    for i in 1..n_rows {
-        for (j, witness_col) in witness_cols.iter_mut().enumerate() {
-            let witness_cols_j_i_min_1 = witness_col[i - 1];
-            witness_col.push(
-                witness_cols_j_i_min_1
-                    + F::from_usize(j + N_PREPROCESSED_COLUMNS)
-                    + (0..N_PREPROCESSED_COLUMNS)
-                        .map(|k| trace[k][i])
-                        .product::<F>(),
-            );
+    let mut prev_values = vec![F::ZERO; N_COLUMNS - N_PREPROCESSED_COLUMNS];
+    let mut column_iters = trace[..N_PREPROCESSED_COLUMNS]
+        .iter()
+        .map(|col| col.iter())
+        .collect::<Vec<_>>();
+    if column_iters.is_empty() {
+        trace.extend(witness_cols);
+        return trace;
+    }
+    for iter in &mut column_iters {
+        iter.next(); // skip first row, already initialised
+    }
+    loop {
+        let mut row_product = F::ONE;
+        let mut progressed = true;
+        for iter in &mut column_iters {
+            match iter.next() {
+                Some(value) => row_product *= *value,
+                None => {
+                    progressed = false;
+                    break;
+                }
+            }
+        }
+        if !progressed {
+            break;
+        }
+        for (j, (witness_col, prev)) in witness_cols
+            .iter_mut()
+            .zip(prev_values.iter_mut())
+            .enumerate()
+        {
+            let next_val = *prev + F::from_usize(j + N_PREPROCESSED_COLUMNS) + row_product;
+            witness_col.push(next_val);
+            *prev = next_val;
         }
     }
     trace.extend(witness_cols);
@@ -131,14 +156,31 @@ fn generate_unstructured_trace<const N_COLUMNS: usize, const N_PREPROCESSED_COLU
         trace.push((0..n_rows).map(|_| rng.random()).collect::<Vec<F>>());
     }
     let mut witness_cols = vec![vec![]; N_COLUMNS - N_PREPROCESSED_COLUMNS];
-    for i in 0..n_rows {
+    let mut column_iters = trace[..N_PREPROCESSED_COLUMNS]
+        .iter()
+        .map(|col| col.iter())
+        .collect::<Vec<_>>();
+    if column_iters.is_empty() {
+        trace.extend(witness_cols);
+        return trace;
+    }
+    loop {
+        let mut row_product = F::ONE;
+        let mut progressed = true;
+        for iter in &mut column_iters {
+            match iter.next() {
+                Some(value) => row_product *= *value,
+                None => {
+                    progressed = false;
+                    break;
+                }
+            }
+        }
+        if !progressed {
+            break;
+        }
         for (j, witness_col) in witness_cols.iter_mut().enumerate() {
-            witness_col.push(
-                F::from_usize(j + N_PREPROCESSED_COLUMNS)
-                    + (0..N_PREPROCESSED_COLUMNS)
-                        .map(|k| trace[k][i])
-                        .product::<F>(),
-            );
+            witness_col.push(F::from_usize(j + N_PREPROCESSED_COLUMNS) + row_product);
         }
     }
     trace.extend(witness_cols);

--- a/crates/air/src/test.rs
+++ b/crates/air/src/test.rs
@@ -106,9 +106,9 @@ fn generate_structured_trace<const N_COLUMNS: usize, const N_PREPROCESSED_COLUMN
     }
     let mut witness_cols = vec![vec![F::ZERO]; N_COLUMNS - N_PREPROCESSED_COLUMNS];
     for i in 1..n_rows {
-        for j in 0..N_COLUMNS - N_PREPROCESSED_COLUMNS {
-            let witness_cols_j_i_min_1 = witness_cols[j][i - 1];
-            witness_cols[j].push(
+        for (j, witness_col) in witness_cols.iter_mut().enumerate() {
+            let witness_cols_j_i_min_1 = witness_col[i - 1];
+            witness_col.push(
                 witness_cols_j_i_min_1
                     + F::from_usize(j + N_PREPROCESSED_COLUMNS)
                     + (0..N_PREPROCESSED_COLUMNS)
@@ -132,8 +132,8 @@ fn generate_unstructured_trace<const N_COLUMNS: usize, const N_PREPROCESSED_COLU
     }
     let mut witness_cols = vec![vec![]; N_COLUMNS - N_PREPROCESSED_COLUMNS];
     for i in 0..n_rows {
-        for j in 0..N_COLUMNS - N_PREPROCESSED_COLUMNS {
-            witness_cols[j].push(
+        for (j, witness_col) in witness_cols.iter_mut().enumerate() {
+            witness_col.push(
                 F::from_usize(j + N_PREPROCESSED_COLUMNS)
                     + (0..N_PREPROCESSED_COLUMNS)
                         .map(|k| trace[k][i])

--- a/crates/air/src/verify.rs
+++ b/crates/air/src/verify.rs
@@ -84,16 +84,18 @@ fn verify_air<EF: ExtensionField<PF<EF>>, A: NormalAir<EF>, AP: PackedAir<EF>>(
     if structured_air {
         verify_structured_columns(
             verifier_state,
-            table.n_columns(),
-            univariate_skips,
-            &inner_sums,
-            &column_groups,
-            &Evaluation::new(
-                outer_statement.point[1..log_length - univariate_skips + 1].to_vec(),
-                outer_statement.value,
-            ),
-            &outer_selector_evals,
-            log_length,
+            StructuredColumnsArgs {
+                n_columns: table.n_columns(),
+                univariate_skips,
+                all_inner_sums: &inner_sums,
+                column_groups,
+                outer_sumcheck_challenge: &Evaluation::new(
+                    outer_statement.point[1..log_length - univariate_skips + 1].to_vec(),
+                    outer_statement.value,
+                ),
+                outer_selector_evals: &outer_selector_evals,
+                log_n_rows: log_length,
+            },
         )
     } else {
         verify_many_unstructured_columns(
@@ -181,16 +183,30 @@ fn verify_many_unstructured_columns<EF: ExtensionField<PF<EF>>>(
     Ok(evaluations_remaining_to_verify)
 }
 
-fn verify_structured_columns<EF: ExtensionField<PF<EF>>>(
-    verifier_state: &mut FSVerifier<EF, impl FSChallenger<EF>>,
+#[derive(Debug)]
+struct StructuredColumnsArgs<'a, EF> {
     n_columns: usize,
     univariate_skips: usize,
-    all_inner_sums: &[EF],
-    column_groups: &[Range<usize>],
-    outer_sumcheck_challenge: &Evaluation<EF>,
-    outer_selector_evals: &[EF],
+    all_inner_sums: &'a [EF],
+    column_groups: &'a [Range<usize>],
+    outer_sumcheck_challenge: &'a Evaluation<EF>,
+    outer_selector_evals: &'a [EF],
     log_n_rows: usize,
+}
+
+fn verify_structured_columns<EF: ExtensionField<PF<EF>>>(
+    verifier_state: &mut FSVerifier<EF, impl FSChallenger<EF>>,
+    args: StructuredColumnsArgs<'_, EF>,
 ) -> Result<Vec<Evaluation<EF>>, ProofError> {
+    let StructuredColumnsArgs {
+        n_columns,
+        univariate_skips,
+        all_inner_sums,
+        column_groups,
+        outer_sumcheck_challenge,
+        outer_selector_evals,
+        log_n_rows,
+    } = args;
     let log_n_groups = log2_ceil_usize(column_groups.len());
     let max_columns_per_group = Iterator::max(column_groups.iter().map(|g| g.len())).unwrap();
     let log_max_columns_per_group = log2_ceil_usize(max_columns_per_group);
@@ -201,9 +217,13 @@ fn verify_structured_columns<EF: ExtensionField<PF<EF>>>(
     let mut column_scalars = vec![];
     let mut index = 0;
     for group in column_groups {
-        for i in index..index + group.len() {
-            column_scalars.push(poly_eq_batching_scalars[i]);
-        }
+        column_scalars.extend(
+            poly_eq_batching_scalars
+                .iter()
+                .skip(index)
+                .take(group.len())
+                .copied(),
+        );
         index += max_columns_per_group.next_power_of_two();
     }
 

--- a/crates/lean_compiler/src/c_compile_final.rs
+++ b/crates/lean_compiler/src/c_compile_final.rs
@@ -152,23 +152,23 @@ fn compile_block(
                 mut arg_c,
                 res,
             } => {
-                if let Some(arg_a_cst) = try_as_constant(&arg_a, compiler) {
-                    if let Some(arg_b_cst) = try_as_constant(&arg_c, compiler) {
-                        // res = constant +/x constant
+                if let Some(arg_a_cst) = try_as_constant(&arg_a, compiler)
+                    && let Some(arg_b_cst) = try_as_constant(&arg_c, compiler)
+                {
+                    // res = constant +/x constant
 
-                        let op_res = operation.compute(arg_a_cst, arg_b_cst);
+                    let op_res = operation.compute(arg_a_cst, arg_b_cst);
 
-                        let res: MemOrFp = res.try_into_mem_or_fp(compiler).unwrap();
+                    let res: MemOrFp = res.try_into_mem_or_fp(compiler).unwrap();
 
-                        low_level_bytecode.push(Instruction::Computation {
-                            operation: Operation::Add,
-                            arg_a: MemOrConstant::zero(),
-                            arg_c: res,
-                            res: MemOrConstant::Constant(op_res),
-                        });
-                        pc += 1;
-                        continue;
-                    }
+                    low_level_bytecode.push(Instruction::Computation {
+                        operation: Operation::Add,
+                        arg_a: MemOrConstant::zero(),
+                        arg_c: res,
+                        res: MemOrConstant::Constant(op_res),
+                    });
+                    pc += 1;
+                    continue;
                 }
 
                 if arg_c.is_constant() {

--- a/crates/lean_prover/src/common.rs
+++ b/crates/lean_prover/src/common.rs
@@ -18,12 +18,12 @@ pub fn get_base_dims(
     log_public_memory: usize,
     private_memory_len: usize,
     bytecode_ending_pc: usize,
-    n_poseidons_16: usize,
-    n_poseidons_24: usize,
-    p16_air_width: usize,
-    p24_air_width: usize,
+    poseidon_counts: (usize, usize),
+    poseidon_widths: (usize, usize),
     n_rows_table_dot_products: usize,
 ) -> Vec<ColDims<F>> {
+    let (n_poseidons_16, n_poseidons_24) = poseidon_counts;
+    let (p16_air_width, p24_air_width) = poseidon_widths;
     let (default_p16_row, default_p24_row) = build_poseidon_columns(
         &[WitnessPoseidon16::poseidon_of_zero()],
         &[WitnessPoseidon24::poseidon_of_zero()],

--- a/crates/lean_prover/src/prove_execution.rs
+++ b/crates/lean_prover/src/prove_execution.rs
@@ -211,10 +211,8 @@ pub fn prove_execution(
         log_public_memory,
         private_memory.len(),
         bytecode.ending_pc,
-        n_poseidons_16,
-        n_poseidons_24,
-        p16_air.width(),
-        p24_air.width(),
+        (n_poseidons_16, n_poseidons_24),
+        (p16_air.width(), p24_air.width()),
         n_rows_table_dot_products,
     );
 
@@ -810,12 +808,14 @@ pub fn prove_execution(
         let index_a: F = dot_product_columns[2][i].as_base().unwrap();
         let index_b: F = dot_product_columns[3][i].as_base().unwrap();
         let index_res: F = dot_product_columns[4][i].as_base().unwrap();
-        for j in 0..DIMENSION {
-            dot_product_indexes_spread[j][i] = index_a + F::from_usize(j);
-            dot_product_indexes_spread[j][i + dot_product_table_length] =
-                index_b + F::from_usize(j);
-            dot_product_indexes_spread[j][i + 2 * dot_product_table_length] =
-                index_res + F::from_usize(j);
+        for (j, column) in dot_product_indexes_spread
+            .iter_mut()
+            .enumerate()
+            .take(DIMENSION)
+        {
+            column[i] = index_a + F::from_usize(j);
+            column[i + dot_product_table_length] = index_b + F::from_usize(j);
+            column[i + 2 * dot_product_table_length] = index_res + F::from_usize(j);
         }
     }
     let dot_product_values_spread = dot_product_indexes_spread

--- a/crates/lean_prover/src/prove_execution.rs
+++ b/crates/lean_prover/src/prove_execution.rs
@@ -992,7 +992,7 @@ pub fn prove_execution(
         &second_batched_whir_config_builder::<EF, EF, _, _, _>(
             whir_config_builder.clone(),
             log2_strict_usize(packed_pcs_witness_base.packed_polynomial.len()),
-            num_packed_vars_for_dims::<EF, EF>(&extension_dims, LOG_SMALLEST_DECOMPOSITION_CHUNK),
+            num_packed_vars_for_dims::<EF>(&extension_dims, LOG_SMALLEST_DECOMPOSITION_CHUNK),
         ),
         &extension_pols,
         &extension_dims,

--- a/crates/lean_prover/src/verify_execution.rs
+++ b/crates/lean_prover/src/verify_execution.rs
@@ -174,10 +174,8 @@ pub fn verify_execution(
         log_public_memory,
         private_memory_len,
         bytecode.ending_pc,
-        n_poseidons_16,
-        n_poseidons_24,
-        p16_air.width(),
-        p24_air.width(),
+        (n_poseidons_16, n_poseidons_24),
+        (p16_air.width(), p24_air.width()),
         n_rows_table_dot_products,
     );
 
@@ -859,8 +857,12 @@ pub fn verify_execution(
         );
 
         let mut dot_product_indexes_inner_evals_incr = vec![EF::ZERO; 8];
-        for i in 0..DIMENSION {
-            dot_product_indexes_inner_evals_incr[i] = dot_product_logup_star_indexes_inner_value
+        for (i, value) in dot_product_indexes_inner_evals_incr
+            .iter_mut()
+            .enumerate()
+            .take(DIMENSION)
+        {
+            *value = dot_product_logup_star_indexes_inner_value
                 + EF::from_usize(i)
                     * [F::ONE, F::ONE, F::ONE, F::ZERO].evaluate(&MultilinearPoint(
                         mem_lookup_eval_indexes_partial_point.0[3 + index_diff..5 + index_diff]

--- a/crates/lean_prover/src/verify_execution.rs
+++ b/crates/lean_prover/src/verify_execution.rs
@@ -548,7 +548,7 @@ pub fn verify_execution(
         &second_batched_whir_config_builder::<EF, EF, _, _, _>(
             whir_config_builder.clone(),
             parsed_commitment_base.num_variables,
-            num_packed_vars_for_dims::<EF, EF>(&extension_dims, LOG_SMALLEST_DECOMPOSITION_CHUNK),
+            num_packed_vars_for_dims::<EF>(&extension_dims, LOG_SMALLEST_DECOMPOSITION_CHUNK),
         ),
         &mut verifier_state,
         &extension_dims,

--- a/crates/lean_prover/witness_generation/src/execution_trace.rs
+++ b/crates/lean_prover/witness_generation/src/execution_trace.rs
@@ -267,10 +267,13 @@ pub fn get_execution_trace(
     }
 
     // repeat the last row to get to a power of two
-    for j in 0..N_INSTRUCTION_COLUMNS + N_EXEC_COLUMNS {
-        let last_value = trace[j][n_cycles - 1];
-        for i in n_cycles..(1 << log_n_cycles_rounded_up) {
-            trace[j][i] = last_value;
+    for column in trace
+        .iter_mut()
+        .take(N_INSTRUCTION_COLUMNS + N_EXEC_COLUMNS)
+    {
+        let last_value = column[n_cycles - 1];
+        for cell in column.iter_mut().skip(n_cycles) {
+            *cell = last_value;
         }
     }
 

--- a/crates/lean_vm/src/memory.rs
+++ b/crates/lean_vm/src/memory.rs
@@ -51,8 +51,8 @@ impl Memory {
     pub fn get_ef_element(&self, index: usize) -> Result<EF, RunnerError> {
         // index: non vectorized pointer
         let mut coeffs = [F::ZERO; DIMENSION];
-        for i in 0..DIMENSION {
-            coeffs[i] = self.get(index + i)?;
+        for (offset, coeff) in coeffs.iter_mut().enumerate() {
+            *coeff = self.get(index + offset)?;
         }
         Ok(EF::from_basis_coefficients_slice(&coeffs).unwrap())
     }

--- a/crates/lookup/src/quotient_gkr.rs
+++ b/crates/lookup/src/quotient_gkr.rs
@@ -215,7 +215,7 @@ where
 
 fn prove_gkr_quotient_step_packed<EF>(
     prover_state: &mut FSProver<EF, impl FSChallenger<EF>>,
-    up_layer_packed: &Vec<EFPacking<EF>>,
+    up_layer_packed: &[EFPacking<EF>],
     claim: &Evaluation<EF>,
 ) -> (Evaluation<EF>, EF, EF)
 where

--- a/crates/rec_aggregation/src/xmss_aggregate.rs
+++ b/crates/rec_aggregation/src/xmss_aggregate.rs
@@ -224,9 +224,7 @@ fn test_xmss_aggregate() {
             &xmss_signature_size_padded.to_string(),
         );
 
-    let bitfield = (0..n_public_keys)
-        .map(|i| i % INV_BITFIELD_DENSITY == 0)
-        .collect::<Vec<_>>();
+    let bitfield = vec![true; n_public_keys];
 
     let mut rng = StdRng::seed_from_u64(0);
     let message_hash: [F; 8] = rng.random();

--- a/crates/sumcheck/src/prove.rs
+++ b/crates/sumcheck/src/prove.rs
@@ -14,6 +14,7 @@ use crate::Mle;
 use crate::MleGroup;
 use crate::SumcheckComputation;
 use crate::SumcheckComputationPacked;
+use crate::SumcheckComputeParams;
 
 #[allow(clippy::too_many_arguments)]
 pub fn prove<'a, EF, SC, SCP, M: Into<MleGroup<'a, EF>>>(
@@ -151,16 +152,20 @@ where
         })
         .collect::<Vec<Vec<PF<EF>>>>();
 
-    p_evals.extend(multilinears.by_ref().sumcheck_compute(
-        &zs,
-        skips,
-        eq_factor.as_ref().map(|(_, eq_mle)| eq_mle),
-        &folding_scalars,
-        computation,
-        computations_packed,
-        batching_scalars,
-        missing_mul_factor,
-    ));
+    p_evals.extend(
+        multilinears
+            .by_ref()
+            .sumcheck_compute(SumcheckComputeParams {
+                zs: &zs,
+                skips,
+                eq_mle: eq_factor.as_ref().map(|(_, eq_mle)| eq_mle),
+                folding_scalars: &folding_scalars,
+                computation,
+                computation_packed: computations_packed,
+                batching_scalars,
+                missing_mul_factor,
+            }),
+    );
 
     if !is_zerofier {
         let missing_sum_z = if let Some((eq_factor, _)) = eq_factor {

--- a/crates/utils/src/display.rs
+++ b/crates/utils/src/display.rs
@@ -5,7 +5,7 @@ pub fn pretty_integer(i: usize) -> String {
     let mut result = String::new();
 
     for (index, ch) in chars.iter().enumerate() {
-        if index > 0 && (chars.len() - index) % 3 == 0 {
+        if index > 0 && (chars.len() - index).is_multiple_of(3) {
             result.push(',');
         }
         result.push(*ch);

--- a/crates/utils/src/misc.rs
+++ b/crates/utils/src/misc.rs
@@ -30,25 +30,25 @@ pub const fn diff_to_next_power_of_two(n: usize) -> usize {
 }
 
 pub fn left_mut<A>(slice: &mut [A]) -> &mut [A] {
-    assert!(slice.len() % 2 == 0);
+    assert!(slice.len().is_multiple_of(2));
     let mid = slice.len() / 2;
     &mut slice[..mid]
 }
 
 pub fn right_mut<A>(slice: &mut [A]) -> &mut [A] {
-    assert!(slice.len() % 2 == 0);
+    assert!(slice.len().is_multiple_of(2));
     let mid = slice.len() / 2;
     &mut slice[mid..]
 }
 
 pub fn left_ref<A>(slice: &[A]) -> &[A] {
-    assert!(slice.len() % 2 == 0);
+    assert!(slice.len().is_multiple_of(2));
     let mid = slice.len() / 2;
     &slice[..mid]
 }
 
 pub fn right_ref<A>(slice: &[A]) -> &[A] {
-    assert!(slice.len() % 2 == 0);
+    assert!(slice.len().is_multiple_of(2));
     let mid = slice.len() / 2;
     &slice[mid..]
 }

--- a/crates/utils/src/univariate.rs
+++ b/crates/utils/src/univariate.rs
@@ -7,10 +7,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
 type CacheKey = (TypeId, usize);
+type CacheValue = Arc<OnceLock<Arc<dyn Any + Send + Sync>>>;
+type SelectorsCache = Mutex<HashMap<CacheKey, CacheValue>>;
 
-static SELECTORS_CACHE: OnceLock<
-    Mutex<HashMap<CacheKey, Arc<OnceLock<Arc<dyn Any + Send + Sync>>>>>,
-> = OnceLock::new();
+static SELECTORS_CACHE: OnceLock<SelectorsCache> = OnceLock::new();
 
 pub fn univariate_selectors<F: Field>(n: usize) -> Arc<Vec<DensePolynomial<F>>> {
     let key = (TypeId::of::<F>(), n);

--- a/src/examples/prove_poseidon2.rs
+++ b/src/examples/prove_poseidon2.rs
@@ -5,13 +5,20 @@ use p3_field::PrimeField64;
 use p3_koala_bear::{KoalaBear, QuinticExtensionFieldKB};
 use p3_symmetric::Permutation;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
-use packed_pcs::*;
+use packed_pcs::{
+    ColDims, packed_pcs_commit, packed_pcs_global_statements_for_prover,
+    packed_pcs_global_statements_for_verifier, packed_pcs_parse_commitment,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
+use std::collections::BTreeMap;
 use std::fmt;
+use std::ops::Range;
 use std::time::{Duration, Instant};
 use utils::{
-    build_merkle_compress, build_merkle_hash, build_poseidon_16_air, build_poseidon_16_air_packed,
-    build_poseidon_24_air, build_poseidon_24_air_packed, build_prover_state, build_verifier_state,
+    FSProver, MY_DIGEST_ELEMS, MyChallenger, MyMerkleCompress, MyMerkleHash, MyWhirConfigBuilder,
+    PF, PFPacking, Poseidon16Air, Poseidon24Air, build_merkle_compress, build_merkle_hash,
+    build_poseidon_16_air, build_poseidon_16_air_packed, build_poseidon_24_air,
+    build_poseidon_24_air_packed, build_prover_state, build_verifier_state,
     generate_trace_poseidon_16, generate_trace_poseidon_24, get_poseidon16, get_poseidon24,
     init_tracing, padd_with_zero_to_next_power_of_two,
 };
@@ -20,6 +27,7 @@ use whir_p3::whir::config::{FoldingFactor, SecurityAssumption, WhirConfig, WhirC
 
 type F = KoalaBear;
 type EF = QuinticExtensionFieldKB;
+type MyWhirConfig = WhirConfig<PF<EF>, EF, MyMerkleHash, MyMerkleCompress, MY_DIGEST_ELEMS>;
 
 #[derive(Clone, Debug)]
 pub struct Poseidon2Benchmark {
@@ -38,7 +46,7 @@ impl fmt::Display for Poseidon2Benchmark {
             1 << self.log_n_poseidons_16,
             1 << self.log_n_poseidons_24,
             self.prover_time.as_millis() as f64 / 1000.0,
-            (((1 << self.log_n_poseidons_16) + (1 << self.log_n_poseidons_24)) as f64
+            (f64::from((1 << self.log_n_poseidons_16) + (1 << self.log_n_poseidons_24))
                 / self.prover_time.as_secs_f64())
             .round() as usize
         )?;
@@ -51,25 +59,43 @@ impl fmt::Display for Poseidon2Benchmark {
     }
 }
 
-pub fn prove_poseidon2(
-    log_n_poseidons_16: usize,
-    log_n_poseidons_24: usize,
-    univariate_skips: usize,
-    folding_factor: FoldingFactor,
-    log_inv_rate: usize,
-    soundness_type: SecurityAssumption,
-    pow_bits: usize,
-    security_level: usize,
-    rs_domain_initial_reduction_factor: usize,
-    max_num_variables_to_send_coeffs: usize,
-    display_logs: bool,
-) -> Poseidon2Benchmark {
-    if display_logs {
-        init_tracing();
-    }
+#[derive(Clone, Debug)]
+pub struct Poseidon2Config {
+    pub log_n_poseidons_16: usize,
+    pub log_n_poseidons_24: usize,
+    pub univariate_skips: usize,
+    pub folding_factor: FoldingFactor,
+    pub log_inv_rate: usize,
+    pub soundness_type: SecurityAssumption,
+    pub pow_bits: usize,
+    pub security_level: usize,
+    pub rs_domain_initial_reduction_factor: usize,
+    pub max_num_variables_to_send_coeffs: usize,
+    pub display_logs: bool,
+}
 
-    let n_poseidons_16 = 1 << log_n_poseidons_16;
-    let n_poseidons_24 = 1 << log_n_poseidons_24;
+struct PoseidonSetup {
+    n_columns_24: usize,
+    log_table_area_16: usize,
+    log_table_area_24: usize,
+    witness_columns_16: Vec<Vec<F>>,
+    witness_columns_24: Vec<Vec<F>>,
+    column_groups_16: Vec<Range<usize>>,
+    column_groups_24: Vec<Range<usize>>,
+    table_16: AirTable<EF, Poseidon16Air<F>, Poseidon16Air<PFPacking<F>>>,
+    table_24: AirTable<EF, Poseidon24Air<F>, Poseidon24Air<PFPacking<F>>>,
+}
+
+struct ProverArtifacts {
+    prover_time: Duration,
+    whir_config_builder: MyWhirConfigBuilder,
+    whir_config: MyWhirConfig,
+    dims: [ColDims<F>; 2],
+}
+
+fn prepare_poseidon(config: &Poseidon2Config) -> PoseidonSetup {
+    let n_poseidons_16 = 1 << config.log_n_poseidons_16;
+    let n_poseidons_24 = 1 << config.log_n_poseidons_24;
 
     let poseidon_air_16 = build_poseidon_16_air();
     let poseidon_air_16_packed = build_poseidon_16_air_packed();
@@ -78,8 +104,8 @@ pub fn prove_poseidon2(
 
     let n_columns_16 = poseidon_air_16.width();
     let n_columns_24 = poseidon_air_24.width();
-    let log_table_area_16 = log_n_poseidons_16 + log2_ceil_usize(n_columns_16);
-    let log_table_area_24 = log_n_poseidons_24 + log2_ceil_usize(n_columns_24);
+    let log_table_area_16 = config.log_n_poseidons_16 + log2_ceil_usize(n_columns_16);
+    let log_table_area_24 = config.log_n_poseidons_24 + log2_ceil_usize(n_columns_24);
 
     let mut rng = StdRng::seed_from_u64(0);
     let inputs_16: Vec<[F; 16]> = (0..n_poseidons_16).map(|_| Default::default()).collect();
@@ -114,76 +140,103 @@ pub fn prove_poseidon2(
                 .to_vec()
         })
         .collect::<Vec<_>>();
-    let column_groups_16 = vec![0..n_columns_16];
-    let column_groups_24 = vec![0..n_columns_24];
-    let witness_16 = AirWitness::new(&witness_columns_16, &column_groups_16);
-    let witness_24 = AirWitness::new(&witness_columns_24, &column_groups_24);
+    let column_groups_16 = vec![Range {
+        start: 0,
+        end: n_columns_16,
+    }];
+    let column_groups_24 = vec![Range {
+        start: 0,
+        end: n_columns_24,
+    }];
 
-    let table_16 = AirTable::<EF, _, _>::new(poseidon_air_16, poseidon_air_16_packed);
-    let table_24 = AirTable::<EF, _, _>::new(poseidon_air_24, poseidon_air_24_packed);
+    let table_16: AirTable<EF, Poseidon16Air<F>, Poseidon16Air<PFPacking<F>>> =
+        AirTable::new(poseidon_air_16, poseidon_air_16_packed);
+    let table_24: AirTable<EF, Poseidon24Air<F>, Poseidon24Air<PFPacking<F>>> =
+        AirTable::new(poseidon_air_24, poseidon_air_24_packed);
 
-    let t = Instant::now();
+    PoseidonSetup {
+        n_columns_24,
+        log_table_area_16,
+        log_table_area_24,
+        witness_columns_16,
+        witness_columns_24,
+        column_groups_16,
+        column_groups_24,
+        table_16,
+        table_24,
+    }
+}
 
-    let mut prover_state = build_prover_state();
+fn run_prover_phase(
+    config: &Poseidon2Config,
+    setup: &PoseidonSetup,
+    witness_16: AirWitness<'_, F>,
+    witness_24: AirWitness<'_, F>,
+    prover_state: &mut FSProver<EF, MyChallenger>,
+) -> ProverArtifacts {
+    let start = Instant::now();
 
     let whir_config_builder = WhirConfigBuilder {
-        folding_factor,
-        soundness_type,
+        folding_factor: config.folding_factor,
+        soundness_type: config.soundness_type,
         merkle_hash: build_merkle_hash(),
         merkle_compress: build_merkle_compress(),
-        pow_bits,
-        max_num_variables_to_send_coeffs,
-        rs_domain_initial_reduction_factor,
-        security_level,
-        starting_log_inv_rate: log_inv_rate,
+        pow_bits: config.pow_bits,
+        max_num_variables_to_send_coeffs: config.max_num_variables_to_send_coeffs,
+        rs_domain_initial_reduction_factor: config.rs_domain_initial_reduction_factor,
+        security_level: config.security_level,
+        starting_log_inv_rate: config.log_inv_rate,
     };
 
-    // let pcs = RingSwitching::<F, EF, _, EXTENSION_DEGREE>::new(pcs);
     let dft = EvalsDft::new(
-        1 << (log2_ceil_usize(n_columns_24)
-            + log_n_poseidons_16.max(log_n_poseidons_24)
-            + log_inv_rate
+        1 << (log2_ceil_usize(setup.n_columns_24)
+            + config.log_n_poseidons_16.max(config.log_n_poseidons_24)
+            + config.log_inv_rate
             - whir_config_builder.folding_factor.at_round(0)),
     );
 
     let commited_trace_polynomial_16 =
-        padd_with_zero_to_next_power_of_two(&witness_columns_16.concat());
+        padd_with_zero_to_next_power_of_two(&setup.witness_columns_16.concat());
     let commited_trace_polynomial_24 =
-        padd_with_zero_to_next_power_of_two(&witness_columns_24.concat());
+        padd_with_zero_to_next_power_of_two(&setup.witness_columns_24.concat());
 
     let dims = [
-        ColDims::dense(log_table_area_16),
-        ColDims::dense(log_table_area_24),
+        ColDims::dense(setup.log_table_area_16),
+        ColDims::dense(setup.log_table_area_24),
     ];
-    let log_smallest_decomposition_chunk = 0; // UNUSED because verything is power of 2
-
-    let commited_data = [
+    let log_smallest_decomposition_chunk = 0;
+    let commited_slices = [
         commited_trace_polynomial_16.as_slice(),
         commited_trace_polynomial_24.as_slice(),
     ];
+
     let commitment_witness = packed_pcs_commit(
         &whir_config_builder,
-        &commited_data,
+        &commited_slices,
         &dims,
         &dft,
-        &mut prover_state,
-        0,
+        prover_state,
+        log_smallest_decomposition_chunk,
     );
 
     let evaluations_remaining_to_prove_16 =
-        table_16.prove_base(&mut prover_state, univariate_skips, witness_16);
+        setup
+            .table_16
+            .prove_base(prover_state, config.univariate_skips, witness_16);
     let evaluations_remaining_to_prove_24 =
-        table_24.prove_base(&mut prover_state, univariate_skips, witness_24);
+        setup
+            .table_24
+            .prove_base(prover_state, config.univariate_skips, witness_24);
 
     let global_statements_to_prove = packed_pcs_global_statements_for_prover(
-        &commited_data,
+        &commited_slices,
         &dims,
         log_smallest_decomposition_chunk,
         &[
             evaluations_remaining_to_prove_16,
             evaluations_remaining_to_prove_24,
         ],
-        &mut prover_state,
+        prover_state,
     );
     let whir_config = WhirConfig::new(
         whir_config_builder.clone(),
@@ -191,54 +244,70 @@ pub fn prove_poseidon2(
     );
     whir_config.prove(
         &dft,
-        &mut prover_state,
+        prover_state,
         global_statements_to_prove,
         commitment_witness.inner_witness,
         &commitment_witness.packed_polynomial,
     );
 
-    let prover_time = t.elapsed();
-    let time = Instant::now();
+    ProverArtifacts {
+        prover_time: start.elapsed(),
+        whir_config_builder,
+        whir_config,
+        dims,
+    }
+}
 
-    let mut verifier_state = build_verifier_state(&prover_state);
+fn run_verifier_phase(
+    config: &Poseidon2Config,
+    setup: &PoseidonSetup,
+    artifacts: &ProverArtifacts,
+    prover_state: &FSProver<EF, MyChallenger>,
+) -> Duration {
+    let start = Instant::now();
+    let mut verifier_state = build_verifier_state(prover_state);
+    let log_smallest_decomposition_chunk = 0;
 
     let packed_parsed_commitment = packed_pcs_parse_commitment(
-        &whir_config_builder,
+        &artifacts.whir_config_builder,
         &mut verifier_state,
-        &dims,
+        &artifacts.dims,
         log_smallest_decomposition_chunk,
     )
     .unwrap();
 
-    let evaluations_remaining_to_verify_16 = table_16
+    let evaluations_remaining_to_verify_16 = setup
+        .table_16
         .verify(
             &mut verifier_state,
-            univariate_skips,
-            log_n_poseidons_16,
-            &column_groups_16,
+            config.univariate_skips,
+            config.log_n_poseidons_16,
+            &setup.column_groups_16,
         )
         .unwrap();
-    let evaluations_remaining_to_verify_24 = table_24
+    let evaluations_remaining_to_verify_24 = setup
+        .table_24
         .verify(
             &mut verifier_state,
-            univariate_skips,
-            log_n_poseidons_24,
-            &column_groups_24,
+            config.univariate_skips,
+            config.log_n_poseidons_24,
+            &setup.column_groups_24,
         )
         .unwrap();
 
     let global_statements_to_verify = packed_pcs_global_statements_for_verifier(
-        &dims,
+        &artifacts.dims,
         log_smallest_decomposition_chunk,
         &[
             evaluations_remaining_to_verify_16,
             evaluations_remaining_to_verify_24,
         ],
         &mut verifier_state,
-        &Default::default(),
+        &BTreeMap::default(),
     )
     .unwrap();
-    whir_config
+    artifacts
+        .whir_config
         .verify(
             &mut verifier_state,
             &packed_parsed_commitment,
@@ -246,14 +315,28 @@ pub fn prove_poseidon2(
         )
         .unwrap();
 
-    let verifier_time = time.elapsed();
+    start.elapsed()
+}
+
+pub fn prove_poseidon2(config: &Poseidon2Config) -> Poseidon2Benchmark {
+    if config.display_logs {
+        init_tracing();
+    }
+
+    let setup = prepare_poseidon(config);
+    let witness_16 = AirWitness::new(&setup.witness_columns_16, &setup.column_groups_16);
+    let witness_24 = AirWitness::new(&setup.witness_columns_24, &setup.column_groups_24);
+
+    let mut prover_state = build_prover_state();
+    let artifacts = run_prover_phase(config, &setup, witness_16, witness_24, &mut prover_state);
+    let verifier_time = run_verifier_phase(config, &setup, &artifacts, &prover_state);
 
     let proof_size = prover_state.proof_data().len() as f64 * (F::ORDER_U64 as f64).log2() / 8.0;
 
     Poseidon2Benchmark {
-        log_n_poseidons_16,
-        log_n_poseidons_24,
-        prover_time,
+        log_n_poseidons_16: config.log_n_poseidons_16,
+        log_n_poseidons_24: config.log_n_poseidons_24,
+        prover_time: artifacts.prover_time,
         verifier_time,
         proof_size,
     }
@@ -267,19 +350,20 @@ mod tests {
 
     #[test]
     fn test_prove_poseidon2() {
-        let benchmark = prove_poseidon2(
-            13,
-            12,
-            4,
-            FoldingFactor::new(5, 3),
-            2,
-            SecurityAssumption::CapacityBound,
-            13,
-            128,
-            1,
-            5,
-            false,
-        );
+        let config = Poseidon2Config {
+            log_n_poseidons_16: 13,
+            log_n_poseidons_24: 12,
+            univariate_skips: 4,
+            folding_factor: FoldingFactor::new(5, 3),
+            log_inv_rate: 2,
+            soundness_type: SecurityAssumption::CapacityBound,
+            pow_bits: 13,
+            security_level: 128,
+            rs_domain_initial_reduction_factor: 1,
+            max_num_variables_to_send_coeffs: 5,
+            display_logs: false,
+        };
+        let benchmark = prove_poseidon2(&config);
         println!("\n{benchmark}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,22 +2,23 @@
 
 mod examples;
 
-use crate::examples::prove_poseidon2::prove_poseidon2;
+use crate::examples::prove_poseidon2::{Poseidon2Config, prove_poseidon2};
 use whir_p3::whir::config::{FoldingFactor, SecurityAssumption};
 
 fn main() {
-    let benchmark = prove_poseidon2(
-        17,
-        17,
-        4,
-        FoldingFactor::new(7, 4),
-        1,
-        SecurityAssumption::CapacityBound,
-        16,
-        128,
-        5,
-        3,
-        true,
-    );
+    let config = Poseidon2Config {
+        log_n_poseidons_16: 17,
+        log_n_poseidons_24: 17,
+        univariate_skips: 4,
+        folding_factor: FoldingFactor::new(7, 4),
+        log_inv_rate: 1,
+        soundness_type: SecurityAssumption::CapacityBound,
+        pow_bits: 16,
+        security_level: 128,
+        rs_domain_initial_reduction_factor: 5,
+        max_num_variables_to_send_coeffs: 3,
+        display_logs: true,
+    };
+    let benchmark = prove_poseidon2(&config);
     println!("\n{benchmark}");
 }


### PR DESCRIPTION
…orted lints now build cleanly.

- `crates/utils/src/misc.rs:33` switched the even-length assertions in the left/right slice helpers to `.is_multiple_of(2)` so Clippy stops flagging the manual modulus checks.
- `crates/utils/src/univariate.rs:9` introduced `CacheValue`/`SelectorsCache` type aliases and reused them in the `SELECTORS_CACHE` static to tame the complex type signature.
- `crates/utils/src/multilinear.rs:24` replaced the raw `transmute` with a typed pointer cast, and in `:186` rewrote the recursion branch to drop needless returns while using `point.is_empty()`. Tests at `:280` and `:298` now iterate directly over mutable coefficients, removing the range-index loops.
- `crates/utils/src/display.rs:8` now relies on `.is_multiple_of(3)` for clarity in the thousands separator logic.

Checks: `cargo fmt`

`cargo clippy --workspace --all-targets -- -Dwarnings` now continues past `crates/utils`, but fails later with pre-existing lints in `crates/packed_pcs` and `crates/sumcheck` (multiple bound locations, unused type parameter, `map`+`flatten`, needless borrows, function argument count). Those remain to be addressed separately.

Next steps:
1. Tackle the newly surfaced Clippy findings in `crates/packed_pcs` and `crates/sumcheck`, or relax the lint levels for those items if appropriate.